### PR TITLE
Set license field in metadata of package

### DIFF
--- a/accera/python/compilers/setup.cfg
+++ b/accera/python/compilers/setup.cfg
@@ -3,6 +3,7 @@ name = accera-compilers
 author = Microsoft Research AI Compilers Team
 author_email = mlodev@microsoft.com
 summary = Accera Compilers
+license = MIT License
 long_description = file: README.md
 long_description_content_type = text/markdown
 license_files = ../../../LICENSE

--- a/accera/python/gpu/setup.cfg
+++ b/accera/python/gpu/setup.cfg
@@ -3,6 +3,7 @@ name = accera-gpu
 author = Microsoft Research AI Compilers Team
 author_email = mlodev@microsoft.com
 summary = Accera GPU Support
+license = MIT License
 long_description = file: README.md
 long_description_content_type = text/markdown
 license_files = ../../../LICENSE

--- a/accera/python/llvm/setup.cfg
+++ b/accera/python/llvm/setup.cfg
@@ -3,6 +3,7 @@ name = accera-llvm
 author = Microsoft Research AI Compilers Team
 author_email = mlodev@microsoft.com
 summary = Accera LLVM Binaries
+license = MIT License
 long_description = file: README.md
 long_description_content_type = text/markdown
 license_files = ../../../LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ author_email = mlodev@microsoft.com
 summary = Accera - An optimizing cross-compiler for compute-intensive code
 long_description = file: README.md
 long_description_content_type = text/markdown
+license = MIT License
 license_files = LICENSE
 platforms = Linux, Darwin, Windows
 classifiers =


### PR DESCRIPTION
Even though license_file and the trove classifiers are set, a package should have the `license field` set to `MIT License` for it to show in the PyPi index as MIT licensed.

The same change should be made to:
- accera-compilers
- accera-gpu
- accera-llvm